### PR TITLE
Don't try to write to a buffered socket if there's no data.

### DIFF
--- a/src/socket_transport.cpp
+++ b/src/socket_transport.cpp
@@ -42,6 +42,9 @@ bool BufferedSocket::ProcessRead()
 
 bool BufferedSocket::ProcessWrite()
 {
+	if (this->write_buffer.empty())
+		return true;
+
 	int count = this->io->Send(this, this->write_buffer);
 	if (count == 0)
 		return false;


### PR DESCRIPTION
This can cause the SSL modules to act weirdly because the TLS library will return 0 bytes written (correctly) which is then interpreted as an error.

<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

## Rationale

<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** <!-- e.g. Linux 3.11 -->
**Compiler name and version:** <!-- e.g. GCC 4.2.0 -->
